### PR TITLE
Pixel2 と iPhoneX の幅に合わせて検索結果と免責事項ページのデザインを調整

### DIFF
--- a/app/javascript/assets/stylesheets/modules/_footer.scss
+++ b/app/javascript/assets/stylesheets/modules/_footer.scss
@@ -6,10 +6,6 @@
   background-color: green;
 }
 
-.footer-wrapper__terms {
-  position: absolute;
-}
-
 .footer {
   background-color: #7797a7;
   bottom: 0;

--- a/app/javascript/assets/stylesheets/modules/_result-page.scss
+++ b/app/javascript/assets/stylesheets/modules/_result-page.scss
@@ -140,12 +140,20 @@
     width: 50px;
     height: 50px;
   }
+
+  // iPhoneX の画面幅
+  @media (max-width: 375px) {
+    width: 50px;
+    height: 50px;
+    margin: 0.5rem 0.1rem 0 1rem;
+  }
 }
 
 .results-item-section__images {
   align-items: center;
 
   @media (max-width: 480px) {
+    display: flex;
     position: relative;
     top: -2rem;
   }

--- a/app/javascript/assets/stylesheets/modules/_tooltip.scss
+++ b/app/javascript/assets/stylesheets/modules/_tooltip.scss
@@ -13,10 +13,9 @@
   @media (max-width: 480px) {
     bottom: 2.5rem;
     font-size: 0.8rem;
-    padding: 0;
     width: 70%;
     left: 11rem;
-    padding: 1rem !important
+    padding: 1rem;
   }
 }
 

--- a/app/javascript/assets/stylesheets/modules/_tooltip.scss
+++ b/app/javascript/assets/stylesheets/modules/_tooltip.scss
@@ -16,6 +16,7 @@
     padding: 0;
     width: 70%;
     left: 11rem;
+    padding: 1rem !important
   }
 }
 


### PR DESCRIPTION
## 概要
close: #98 
Pixel2 と iPhoneX の幅に合わせて、検索結果と免責事項ページのデザインを調整しました。

## 動作確認

| 修正前 | 修正後（iPhoneXの画面）|
| :----: | :----:|
| ![Screen Shot 2021-06-05 at 14 54 37](https://user-images.githubusercontent.com/51867807/120881983-db3dc680-c60f-11eb-9616-7d722b0aca01.png) | ![Screen Shot 2021-06-05 at 14 47 46](https://user-images.githubusercontent.com/51867807/120881987-e2fd6b00-c60f-11eb-90cc-310d54d0b1d9.png) |

## 参考