### PR TITLE
スマホの画面幅でスクロールの挙動がぎこちなくなる問題を解消

### DIFF
--- a/app/javascript/assets/stylesheets/modules/_footer.scss
+++ b/app/javascript/assets/stylesheets/modules/_footer.scss
@@ -14,6 +14,7 @@
   display: flex;
   justify-content: center;
   align-items: center;
+  margin-top: 1rem;
 }
 
 .footer__copyright {

--- a/app/javascript/assets/stylesheets/modules/_header.scss
+++ b/app/javascript/assets/stylesheets/modules/_header.scss
@@ -34,4 +34,8 @@
   font-size: 2.5rem;
   text-decoration: none;
   // TODO: フォントを考える
+
+  @media (max-width: 480px) {
+    margin-left: 1rem;
+  }
 }

--- a/app/javascript/assets/stylesheets/modules/_result-page.scss
+++ b/app/javascript/assets/stylesheets/modules/_result-page.scss
@@ -9,7 +9,7 @@
 
   @media (max-width: 480px) {
     margin-left: 0.5rem;
-    overflow-x: hidden;
+    margin-top: 1rem;
   }
 }
 
@@ -21,13 +21,6 @@
   @media (max-width: 480px) {
     display: flex;
     margin-bottom: 0;
-  }
-}
-
-.results-section {
-  @media (max-width: 480px) {
-    margin-left: 1rem;
-    overflow-x: hidden;
   }
 }
 
@@ -80,8 +73,15 @@
   @media (max-width: 480px) {
     width: 160px;
     height: 160px;
-    border: 1px solid #808080;
     position: relative;
+  }
+}
+
+.results-item-image__layout {
+  @media (max-width: 480px) {
+    width: 160px;
+    height: 160px;
+    border: 1px solid #808080;
   }
 }
 
@@ -137,12 +137,6 @@
   margin: 0.5rem 1rem 0 1rem;
 
   @media (max-width: 480px) {
-    width: 50px;
-    height: 50px;
-  }
-
-  // iPhoneX の画面幅
-  @media (max-width: 375px) {
     width: 50px;
     height: 50px;
     margin: 0.5rem 0.1rem 0 1rem;

--- a/app/javascript/src/components/Result.vue
+++ b/app/javascript/src/components/Result.vue
@@ -1,6 +1,8 @@
 <template>
   <div class="results-item">
-    <img :src="thumbnail()" alt="" class="results-item__image" />
+    <div class="results-item-image__layout">
+      <img :src="thumbnail()" alt="" class="results-item__image" />
+    </div>
     <div class="results-item-section">
       <div class="results-item-section__explain">
         <p class="results-item-section-explain__title" data-test="title">

--- a/app/javascript/src/components/ResultsList.vue
+++ b/app/javascript/src/components/ResultsList.vue
@@ -1,5 +1,5 @@
 <template>
-  <div>
+  <div class="result-section">
     <h2 class="result-section__title">検索結果一覧</h2>
     <pagination></pagination>
     <div


### PR DESCRIPTION
## 概要
close: #106

検索結果一覧画面において、スマホの画面幅でスクロールの挙動がぎこちなくなる問題を解消しました。
加えて、検索結果一覧画面で画像の幅の違いによるデザインの乱れを修正しました。

