### PR TITLE
楽曲シェアのために生成されたURLにSoundLinksのURLを追加

### DIFF
--- a/frontend/src/components/Result.vue
+++ b/frontend/src/components/Result.vue
@@ -103,6 +103,7 @@ export default defineComponent({
       if (resultItem.kkboxUrl) {
         urls.push(`KKBOX\n${resultItem.kkboxUrl}`);
       }
+      urls.push('\nCreated by https://sound-links.com');
 
       return urls.join('\n');
     }

--- a/frontend/src/components/Result.vue
+++ b/frontend/src/components/Result.vue
@@ -74,6 +74,7 @@ import {
   PropType,
 } from 'vue';
 import { result } from '@/types/result';
+import buildUrls from '@/utils/buildUrls';
 import truncateText from '@/utils/truncateText';
 
 const TOOLTIP_SHOW_TIME = 3000;
@@ -91,25 +92,8 @@ export default defineComponent({
       isCopiedUrls: false,
     });
 
-    function urlsText(resultItem: result): string {
-      const urls = [`${resultItem.title}(${resultItem.artist})`];
-
-      if (resultItem.spotifyUrl) {
-        urls.push(`Spotify\n${resultItem.spotifyUrl}`);
-      }
-      if (resultItem.appleMusicUrl) {
-        urls.push(`Apple Music\n${resultItem.appleMusicUrl}`);
-      }
-      if (resultItem.kkboxUrl) {
-        urls.push(`KKBOX\n${resultItem.kkboxUrl}`);
-      }
-      urls.push('\nCreated by https://sound-links.com');
-
-      return urls.join('\n');
-    }
-
     function copyUrlsToClipBoard(resultItem: result): void {
-      navigator.clipboard.writeText(urlsText(resultItem)).then(() => {
+      navigator.clipboard.writeText(buildUrls(resultItem)).then(() => {
         state.isCopiedUrls = true;
         setTimeout(() => {
           state.isCopiedUrls = false;

--- a/frontend/src/utils/buildUrls.ts
+++ b/frontend/src/utils/buildUrls.ts
@@ -1,0 +1,18 @@
+import { result } from '@/types/result';
+
+export default function urlsText(resultItem: result): string {
+  const urls = [`${resultItem.title}(${resultItem.artist})`];
+
+  if (resultItem.spotifyUrl) {
+    urls.push(`Spotify\n${resultItem.spotifyUrl}`);
+  }
+  if (resultItem.appleMusicUrl) {
+    urls.push(`Apple Music\n${resultItem.appleMusicUrl}`);
+  }
+  if (resultItem.kkboxUrl) {
+    urls.push(`KKBOX\n${resultItem.kkboxUrl}`);
+  }
+  urls.push('\nCreated by https://sound-links.com');
+
+  return urls.join('\n');
+}

--- a/frontend/tests/unit/utils/buildUrls.spec.ts
+++ b/frontend/tests/unit/utils/buildUrls.spec.ts
@@ -1,0 +1,73 @@
+import { result } from '@/types/result';
+import buildUrls from '@/utils/buildUrls';
+
+describe('buildUrls', () => {
+  it('Spotify・AppleMusic・KKBOXのURLが渡された場合', () => {
+    const resultItem :result = {
+      id: 1,
+      isrc: 'JPKS00400641',
+      thumbnailUrl: 'https://is3-ssl.mzstatic.com/image/thumb/Music124/v4/5a/6f/de/5a6fdeff-ba89-e6c4-dd0f-982481264c46/jacket_KSXX01381B00Z_550.jpg/300x300bb.jpeg',
+      title: 'リライト',
+      artist: 'ASIAN KUNG-FU GENERATION',
+      spotifyUrl: 'https://open.spotify.com/track/52q1x282D5DvSVNxJZHQPB',
+      appleMusicUrl: 'https://music.apple.com/jp/album/%E8%8D%92%E9%87%8E%E3%82%92%E6%AD%A9%E3%81%91/1536495860?i=1536495861',
+      kkboxUrl: 'https://www.kkbox.com/jp/ja/song/uKa00E1MM52Mjf7iMjf7i0XL-index.html',
+    };
+
+    const expected = `リライト(ASIAN KUNG-FU GENERATION)
+    Spotify
+    https://open.spotify.com/track/52q1x282D5DvSVNxJZHQPB
+    Apple Music
+    https://music.apple.com/jp/album/%E8%8D%92%E9%87%8E%E3%82%92%E6%AD%A9%E3%81%91/1536495860?i=1536495861
+    KKBOX
+    https://www.kkbox.com/jp/ja/song/uKa00E1MM52Mjf7iMjf7i0XL-index.html
+
+    Created by https://sound-links.com`.replace(/^ +/gm, '');
+
+    expect(buildUrls(resultItem)).toBe(expected);
+  });
+
+  it('AppleMusic・KKBOXのURLが渡された場合', () => {
+    const resultItem :result = {
+      id: 1,
+      isrc: 'JPKS00400641',
+      thumbnailUrl: 'https://is3-ssl.mzstatic.com/image/thumb/Music124/v4/5a/6f/de/5a6fdeff-ba89-e6c4-dd0f-982481264c46/jacket_KSXX01381B00Z_550.jpg/300x300bb.jpeg',
+      title: 'リライト',
+      artist: 'ASIAN KUNG-FU GENERATION',
+      spotifyUrl: '',
+      appleMusicUrl: 'https://music.apple.com/jp/album/%E8%8D%92%E9%87%8E%E3%82%92%E6%AD%A9%E3%81%91/1536495860?i=1536495861',
+      kkboxUrl: 'https://www.kkbox.com/jp/ja/song/uKa00E1MM52Mjf7iMjf7i0XL-index.html',
+    };
+
+    const expected = `リライト(ASIAN KUNG-FU GENERATION)
+    Apple Music
+    https://music.apple.com/jp/album/%E8%8D%92%E9%87%8E%E3%82%92%E6%AD%A9%E3%81%91/1536495860?i=1536495861
+    KKBOX
+    https://www.kkbox.com/jp/ja/song/uKa00E1MM52Mjf7iMjf7i0XL-index.html
+    
+    Created by https://sound-links.com`.replace(/^ +/gm, '');
+
+    expect(buildUrls(resultItem)).toBe(expected);
+  });
+
+  it('KKBOXのURLが渡された場合', () => {
+    const resultItem :result = {
+      id: 1,
+      isrc: 'JPKS00400641',
+      thumbnailUrl: 'https://is3-ssl.mzstatic.com/image/thumb/Music124/v4/5a/6f/de/5a6fdeff-ba89-e6c4-dd0f-982481264c46/jacket_KSXX01381B00Z_550.jpg/300x300bb.jpeg',
+      title: 'リライト',
+      artist: 'ASIAN KUNG-FU GENERATION',
+      spotifyUrl: '',
+      appleMusicUrl: '',
+      kkboxUrl: 'https://www.kkbox.com/jp/ja/song/uKa00E1MM52Mjf7iMjf7i0XL-index.html',
+    };
+
+    const expected = `リライト(ASIAN KUNG-FU GENERATION)
+    KKBOX
+    https://www.kkbox.com/jp/ja/song/uKa00E1MM52Mjf7iMjf7i0XL-index.html
+    
+    Created by https://sound-links.com`.replace(/^ +/gm, '');
+
+    expect(buildUrls(resultItem)).toBe(expected);
+  });
+});


### PR DESCRIPTION
## 概要

ref: https://github.com/koheitakahashi/sound_links/issues/139

## やったこと

楽曲シェアのために生成されたURLにSoundLinksのURLを追加しました。
また、VueコンポーネントにURL生成処理があるとテストしづらかったため、生成処理を `utils` に切り出して、テストを追加しました。

## 動作確認

修正後の画面を操作して、以下のテキストがコピーされるのを確認しました。

```
リライト(ASIAN KUNG-FU GENERATION)
Spotify
https://open.spotify.com/track/3txqYlzoDZGLoW8MGll9tQ
Apple Music
https://music.apple.com/jp/album/%E3%83%AA%E3%83%A9%E3%82%A4%E3%83%88/1536394883?i=1536394888
KKBOX
https://www.kkbox.com/jp/ja/song/FcqGD-90I.n6HlVI7lVI70P4-index.html

Created by https://sound-links.com
```
